### PR TITLE
Add Authentication

### DIFF
--- a/src/actions/accounts.js
+++ b/src/actions/accounts.js
@@ -2,8 +2,10 @@ export const FETCH_ACCOUNTS_REQUEST = 'FETCH_ACCOUNTS_REQUEST';
 export const FETCH_ACCOUNTS_SUCCESS = 'FETCH_ACCOUNTS_SUCCESS';
 export const FETCH_ACCOUNTS_FAILURE = 'FETCH_ACCOUNTS_FAILURE';
 
-export const fetchAccountsRequest = () => ({
+export const fetchAccountsRequest = (resolve, reject) => ({
   type: FETCH_ACCOUNTS_REQUEST,
+  resolve,
+  reject,
 });
 
 export const fetchAccountsSuccess = accounts => ({
@@ -11,7 +13,7 @@ export const fetchAccountsSuccess = accounts => ({
   accounts,
 });
 
-export const fetchAccountsFailure = message => ({
+export const fetchAccountsFailure = error => ({
   type: FETCH_ACCOUNTS_FAILURE,
-  message,
+  message: error.message,
 });

--- a/src/actions/authentication.js
+++ b/src/actions/authentication.js
@@ -2,9 +2,11 @@ export const SIGN_IN_REQUEST = 'SIGN_IN_REQUEST';
 export const SIGN_IN_SUCCESS = 'SIGN_IN_SUCCESS';
 export const SIGN_IN_FAILURE = 'SIGN_IN_FAILURE';
 
-export const signInRequest = credentials => ({
+export const signInRequest = (values, resolve, reject) => ({
   type: SIGN_IN_REQUEST,
-  credentials,
+  values,
+  resolve,
+  reject,
 });
 
 export const signInSuccess = data => ({

--- a/src/actions/authentication.js
+++ b/src/actions/authentication.js
@@ -2,6 +2,10 @@ export const SIGN_IN_REQUEST = 'SIGN_IN_REQUEST';
 export const SIGN_IN_SUCCESS = 'SIGN_IN_SUCCESS';
 export const SIGN_IN_FAILURE = 'SIGN_IN_FAILURE';
 
+export const SIGN_OUT_REQUEST = 'SIGN_OUT_REQUEST';
+export const SIGN_OUT_SUCCESS = 'SIGN_OUT_SUCCESS';
+export const SIGN_OUT_FAILURE = 'SIGN_OUT_FAILURE';
+
 export const signInRequest = (values, resolve, reject) => ({
   type: SIGN_IN_REQUEST,
   values,
@@ -16,5 +20,19 @@ export const signInSuccess = data => ({
 
 export const signInFailure = error => ({
   type: SIGN_IN_FAILURE,
+  message: error.message,
+});
+
+export const signOutRequest = resolve => ({
+  type: SIGN_OUT_REQUEST,
+  resolve,
+});
+
+export const signOutSuccess = () => ({
+  type: SIGN_OUT_SUCCESS,
+});
+
+export const signOutFailure = error => ({
+  type: SIGN_OUT_FAILURE,
   message: error.message,
 });

--- a/src/components/Accounts/Pages/List/List.jsx
+++ b/src/components/Accounts/Pages/List/List.jsx
@@ -51,7 +51,9 @@ List.propTypes = {
 
 class AccountsList extends React.Component {
   componentDidMount() {
-    this.props.dispatch(fetchAccountsRequest());
+    return new Promise((resolve, reject) => {
+      this.props.dispatch(fetchAccountsRequest(resolve, reject));
+    });
   }
 
   render() {

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -14,7 +14,27 @@ import MenuIcon from 'material-ui-icons/Menu';
 import styles from './styles';
 import { openSideBar } from '../../actions/navigation';
 
-export const Header = ({ classes, sideBarOpen, onSideBarClick }) => (
+const SignInButton = () => (
+  <Button
+    color="contrast"
+    component={Link}
+    to="/sign_in"
+  >
+    Sign In
+  </Button>
+);
+
+const SignOutButton = () => (
+  <Button
+    color="contrast"
+    component={Link}
+    to="/"
+  >
+    Sign Out
+  </Button>
+);
+
+export const Header = ({ classes, sideBarOpen, onSideBarClick, isAuthenticated }) => (
   <div>
     <AppBar className={classNames(classes.appBar, sideBarOpen && classes.appBarShift)}>
       <Toolbar disableGutters={!sideBarOpen}>
@@ -29,13 +49,11 @@ export const Header = ({ classes, sideBarOpen, onSideBarClick }) => (
         <Typography type="title" color="inherit" className={classes.flex} noWrap>
           Open Budget
         </Typography>
-        <Button
-          color="contrast"
-          component={Link}
-          to="/sign_in"
-        >
-          Sign In
-        </Button>
+        {isAuthenticated ?
+          <SignOutButton />
+          :
+          <SignInButton />
+        }
       </Toolbar>
     </AppBar>
   </div>
@@ -45,10 +63,12 @@ Header.propTypes = {
   classes: PropTypes.object.isRequired,
   sideBarOpen: PropTypes.bool.isRequired,
   onSideBarClick: PropTypes.func.isRequired,
+  isAuthenticated: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = state => ({
   sideBarOpen: state.navigation.sideBar.open,
+  isAuthenticated: state.authentication.isAuthenticated,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -13,6 +13,7 @@ import MenuIcon from 'material-ui-icons/Menu';
 
 import styles from './styles';
 import { openSideBar } from '../../actions/navigation';
+import { signOutRequest } from '../../actions/authentication';
 
 const SignInButton = () => (
   <Button
@@ -24,17 +25,28 @@ const SignInButton = () => (
   </Button>
 );
 
-const SignOutButton = () => (
+const SignOutButton = ({ onSignOutClick }) => (
   <Button
     color="contrast"
     component={Link}
     to="/"
+    onClick={onSignOutClick}
   >
     Sign Out
   </Button>
 );
 
-export const Header = ({ classes, sideBarOpen, onSideBarClick, isAuthenticated }) => (
+SignOutButton.propTypes = {
+  onSignOutClick: PropTypes.func.isRequired,
+};
+
+export const Header = ({
+  classes,
+  sideBarOpen,
+  onSideBarClick,
+  isAuthenticated,
+  onSignOutClick,
+}) => (
   <div>
     <AppBar className={classNames(classes.appBar, sideBarOpen && classes.appBarShift)}>
       <Toolbar disableGutters={!sideBarOpen}>
@@ -50,7 +62,7 @@ export const Header = ({ classes, sideBarOpen, onSideBarClick, isAuthenticated }
           Open Budget
         </Typography>
         {isAuthenticated ?
-          <SignOutButton />
+          <SignOutButton onSignOutClick={onSignOutClick} />
           :
           <SignInButton />
         }
@@ -64,6 +76,7 @@ Header.propTypes = {
   sideBarOpen: PropTypes.bool.isRequired,
   onSideBarClick: PropTypes.func.isRequired,
   isAuthenticated: PropTypes.bool.isRequired,
+  onSignOutClick: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => ({
@@ -74,6 +87,11 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
   onSideBarClick: () => {
     dispatch(openSideBar());
+  },
+  onSignOutClick: () => {
+    return new Promise((resolve) => {
+      dispatch(signOutRequest(resolve));
+    });
   },
 });
 

--- a/src/components/SignIn/SignIn.jsx
+++ b/src/components/SignIn/SignIn.jsx
@@ -1,3 +1,4 @@
+/* eslint arrow-body-style: 0 */
 import React from 'react';
 import PropTypes from 'prop-types';
 import withStyles from 'material-ui/styles/withStyles';
@@ -57,7 +58,9 @@ SignIn.propTypes = {
 
 const mapDispatchToProps = dispatch => ({
   onSubmit: (values) => {
-    dispatch(signInRequest(values));
+    return new Promise((resolve, reject) => {
+      dispatch(signInRequest(values, resolve, reject));
+    });
   },
 });
 

--- a/src/components/SignIn/SignIn.jsx
+++ b/src/components/SignIn/SignIn.jsx
@@ -7,54 +7,66 @@ import Paper from 'material-ui/Paper';
 import Typography from 'material-ui/Typography';
 import { reduxForm, Field } from 'redux-form';
 import Button from 'material-ui/Button';
+import { Redirect } from 'react-router-dom';
 
 import styles from './styles';
 import { signInRequest } from '../../actions/authentication';
 
 import TextField from '../Form/TextField';
 
-const SignIn = ({ classes, handleSubmit, onSubmit }) => (
-  <Paper className={classes.root} elevation={4}>
-    <Typography type="headline" component="h3">
-      Sign In
-    </Typography>
-    <form onSubmit={handleSubmit(onSubmit)}>
-      <div>
-        <Field
-          id="email"
-          name="email"
-          type="email"
-          component={TextField}
-          label="Email"
-        />
-      </div>
-      <div>
-        <Field
-          id="password"
-          name="password"
-          type="password"
-          component={TextField}
-          label="Password"
-        />
-      </div>
-      <div>
-        <Button
-          raised
-          color="primary"
-          type="submit"
-        >
-          Sign In
-        </Button>
-      </div>
-    </form>
-  </Paper>
-);
+const SignIn = ({ classes, handleSubmit, onSubmit, isAuthenticated }) => {
+  if (isAuthenticated) {
+    return <Redirect to="/" />;
+  }
+
+  return (
+    <Paper className={classes.root} elevation={4}>
+      <Typography type="headline" component="h3">
+        Sign In
+      </Typography>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <div>
+          <Field
+            id="email"
+            name="email"
+            type="email"
+            component={TextField}
+            label="Email"
+          />
+        </div>
+        <div>
+          <Field
+            id="password"
+            name="password"
+            type="password"
+            component={TextField}
+            label="Password"
+          />
+        </div>
+        <div>
+          <Button
+            raised
+            color="primary"
+            type="submit"
+          >
+            Sign In
+          </Button>
+        </div>
+      </form>
+    </Paper>
+  );
+};
 
 SignIn.propTypes = {
   classes: PropTypes.object.isRequired,
   handleSubmit: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
+  isAuthenticated: PropTypes.bool.isRequired,
 };
+
+const mapStateToProps = state => ({
+  isAuthenticated: state.authentication.isAuthenticated,
+});
 
 const mapDispatchToProps = dispatch => ({
   onSubmit: (values) => {
@@ -68,4 +80,4 @@ const SignInWithStyle = withStyles(styles)(SignIn);
 
 const SignInForm = reduxForm({ form: 'signIn' })(SignInWithStyle);
 
-export default connect(null, mapDispatchToProps)(SignInForm);
+export default connect(mapStateToProps, mapDispatchToProps)(SignInForm);

--- a/src/reducers/authentication.js
+++ b/src/reducers/authentication.js
@@ -2,6 +2,9 @@ import {
   SIGN_IN_REQUEST,
   SIGN_IN_SUCCESS,
   SIGN_IN_FAILURE,
+  SIGN_OUT_REQUEST,
+  SIGN_OUT_SUCCESS,
+  SIGN_OUT_FAILURE,
 } from '../actions/authentication';
 
 const initialState = {
@@ -40,6 +43,30 @@ const authentication = (state = initialState, { type, ...payload }) => {
         success: false,
         message: payload.message,
         authToken: null,
+      };
+    case SIGN_OUT_REQUEST:
+      return {
+        ...state,
+        isAuthenticated: true,
+        isFetching: true,
+        success: false,
+        message: null,
+      };
+    case SIGN_OUT_SUCCESS:
+      return {
+        ...state,
+        isAuthenticated: false,
+        isFetching: false,
+        success: true,
+        message: null,
+      };
+    case SIGN_OUT_FAILURE:
+      return {
+        ...state,
+        isAuthenticated: true,
+        isFetching: false,
+        success: false,
+        message: payload.message,
       };
     default:
       return state;

--- a/src/reducers/authentication.js
+++ b/src/reducers/authentication.js
@@ -5,11 +5,11 @@ import {
 } from '../actions/authentication';
 
 const initialState = {
-  isAuthenticated: false,
+  isAuthenticated: !!localStorage.getItem('authToken'),
   isFetching: false,
   success: false,
   message: null,
-  authToken: null,
+  authToken: localStorage.getItem('authToken'),
 };
 
 const authentication = (state = initialState, { type, ...payload }) => {

--- a/src/sagas/accounts.js
+++ b/src/sagas/accounts.js
@@ -14,12 +14,15 @@ function* fetchAccounts() {
 
   if (response && !error) {
     resolve();
-    const normalizedAccounts = Object.entries(response.account).map(account => ({
-      id: account[1].id,
-      name: account[1].attributes.name,
-      description: account[1].attributes.description,
-      category: account[1].attributes.category,
-    }));
+    let normalizedAccounts = [];
+    if (Object.keys(response).length > 0) {
+      normalizedAccounts = Object.entries(response.account).map(account => ({
+        id: account[1].id,
+        name: account[1].attributes.name,
+        description: account[1].attributes.description,
+        category: account[1].attributes.category,
+      }));
+    }
     yield put(fetchAccountsSuccess(normalizedAccounts));
   } else {
     reject();

--- a/src/sagas/accounts.js
+++ b/src/sagas/accounts.js
@@ -1,0 +1,33 @@
+import { call, put, takeEvery } from 'redux-saga/effects';
+
+import { api } from '../services';
+
+import {
+  FETCH_ACCOUNTS_REQUEST,
+  FETCH_ACCOUNTS_SUCCESS,
+  FETCH_ACCOUNTS_FAILURE,
+} from '../actions/accounts';
+
+function* fetchAccounts() {
+  try {
+    const apiCall = yield call(api.fetchAccounts);
+    const normalizedAccounts = Object.entries(apiCall.response.account).map((account) => {
+      return {
+        id: account[1].id,
+        name: account[1].attributes.name,
+        description: account[1].attributes.description,
+        category: account[1].attributes.category,
+      };
+    });
+
+    yield put({ type: FETCH_ACCOUNTS_SUCCESS, accounts: normalizedAccounts });
+  } catch (e) {
+    yield put({ type: FETCH_ACCOUNTS_FAILURE, message: e.message });
+  }
+}
+
+function* watchFetchAccounts() {
+  yield takeEvery(FETCH_ACCOUNTS_REQUEST, fetchAccounts);
+}
+
+export default watchFetchAccounts;

--- a/src/sagas/accounts.js
+++ b/src/sagas/accounts.js
@@ -14,14 +14,12 @@ function* fetchAccounts() {
 
   if (response && !error) {
     resolve();
-    const normalizedAccounts = Object.entries(response.account).map((account) => {
-      return {
-        id: account[1].id,
-        name: account[1].attributes.name,
-        description: account[1].attributes.description,
-        category: account[1].attributes.category,
-      };
-    });
+    const normalizedAccounts = Object.entries(response.account).map(account => ({
+      id: account[1].id,
+      name: account[1].attributes.name,
+      description: account[1].attributes.description,
+      category: account[1].attributes.category,
+    }));
     yield put(fetchAccountsSuccess(normalizedAccounts));
   } else {
     reject();

--- a/src/sagas/authentication.js
+++ b/src/sagas/authentication.js
@@ -4,11 +4,13 @@ import { api } from '../services';
 
 import {
   SIGN_IN_REQUEST,
+  SIGN_OUT_REQUEST,
   signInSuccess,
   signInFailure,
+  signOutSuccess,
 } from '../actions/authentication';
 
-function* signInUser() {
+export function* signInUser() {
   const { values, resolve, reject } = yield take(SIGN_IN_REQUEST);
   const { response, error } = yield call(api.signInUser, values.email, values.password);
   if (response && !error) {
@@ -21,4 +23,11 @@ function* signInUser() {
   }
 }
 
-export default signInUser;
+export function* signOutUser() {
+  const { resolve } = yield take(SIGN_OUT_REQUEST);
+  yield call(api.signOutUser, localStorage.getItem('authToken'));
+
+  resolve();
+  localStorage.removeItem('authToken');
+  yield put(signOutSuccess());
+}

--- a/src/sagas/authentication.js
+++ b/src/sagas/authentication.js
@@ -13,6 +13,7 @@ function* signInUser() {
   const { response, error } = yield call(api.signInUser, values.email, values.password);
   if (response && !error) {
     resolve();
+    localStorage.setItem('authToken', response.access_token);
     yield put(signInSuccess(response));
   } else {
     reject();

--- a/src/sagas/authentication.js
+++ b/src/sagas/authentication.js
@@ -1,0 +1,23 @@
+import { call, put, take } from 'redux-saga/effects';
+
+import { api } from '../services';
+
+import {
+  SIGN_IN_REQUEST,
+  signInSuccess,
+  signInFailure,
+} from '../actions/authentication';
+
+function* signInUser() {
+  const { values, resolve, reject } = yield take(SIGN_IN_REQUEST);
+  const { response, error } = yield call(api.signInUser, values.email, values.password);
+  if (response && !error) {
+    resolve();
+    yield put(signInSuccess(response));
+  } else {
+    reject();
+    yield put(signInFailure(error));
+  }
+}
+
+export default signInUser;

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -1,11 +1,9 @@
 /* eslint arrow-body-style: 0 */
 
-import { all } from 'redux-saga/effects';
+import { fork } from 'redux-saga/effects';
 
-import watchFetchAccounts from './accounts';
+import fetchAccounts from './accounts';
 
 export default function* rootSaga() {
-  yield all([
-    watchFetchAccounts(),
-  ]);
+  yield fork(fetchAccounts);
 }

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -1,36 +1,8 @@
 /* eslint arrow-body-style: 0 */
 
-import { call, put, takeEvery, all } from 'redux-saga/effects';
+import { all } from 'redux-saga/effects';
 
-import { api } from '../services';
-
-import {
-  FETCH_ACCOUNTS_REQUEST,
-  FETCH_ACCOUNTS_SUCCESS,
-  FETCH_ACCOUNTS_FAILURE,
-} from '../actions/accounts';
-
-function* fetchAccounts() {
-  try {
-    const apiCall = yield call(api.fetchAccounts);
-    const normalizedAccounts = Object.entries(apiCall.response.account).map((account) => {
-      return {
-        id: account[1].id,
-        name: account[1].attributes.name,
-        description: account[1].attributes.description,
-        category: account[1].attributes.category,
-      };
-    });
-
-    yield put({ type: FETCH_ACCOUNTS_SUCCESS, accounts: normalizedAccounts });
-  } catch (e) {
-    yield put({ type: FETCH_ACCOUNTS_FAILURE, message: e.message });
-  }
-}
-
-function* watchFetchAccounts() {
-  yield takeEvery(FETCH_ACCOUNTS_REQUEST, fetchAccounts);
-}
+import watchFetchAccounts from './accounts';
 
 export default function* rootSaga() {
   yield all([

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -3,7 +3,9 @@
 import { fork } from 'redux-saga/effects';
 
 import fetchAccounts from './accounts';
+import signInUser from './authentication';
 
 export default function* rootSaga() {
   yield fork(fetchAccounts);
+  yield fork(signInUser);
 }

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -3,9 +3,10 @@
 import { fork } from 'redux-saga/effects';
 
 import fetchAccounts from './accounts';
-import signInUser from './authentication';
+import { signInUser, signOutUser } from './authentication';
 
 export default function* rootSaga() {
   yield fork(fetchAccounts);
   yield fork(signInUser);
+  yield fork(signOutUser);
 }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -4,7 +4,7 @@ import 'isomorphic-fetch';
 
 const API_HOST = (process.env.NODE_ENV === 'development') ? 'http://localhost:4000/api/' : 'https://api.openbudget.xyz/api/';
 
-function callApi(endpoint, method = 'get', body = {}) {
+function callApi(endpoint, method = 'get', headers = {}, body = {}) {
   const fullUrl = (endpoint.indexOf(API_HOST) === -1) ? API_HOST + endpoint : endpoint;
   let options = {
     method,
@@ -13,6 +13,11 @@ function callApi(endpoint, method = 'get', body = {}) {
       'Content-Type': 'application/vnd.api+json',
     },
   };
+
+  if (Object.keys(headers).length > 0) {
+    const modifiedHeaders = Object.assign(options.headers, headers);
+    options = Object.assign(options, { headers: modifiedHeaders });
+  }
 
   if (Object.keys(body).length > 0) {
     const normalizedBody = {
@@ -53,4 +58,4 @@ function callApi(endpoint, method = 'get', body = {}) {
 export const fetchAccounts = () => callApi('accounts');
 export const fetchAccount = id => callApi(`accounts/${id}`);
 
-export const signInUser = (email, password) => callApi('auth/token', 'post', { email, password });
+export const signInUser = (email, password) => callApi('auth/token', 'post', {}, { email, password });

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -6,7 +6,7 @@ const API_HOST = (process.env.NODE_ENV === 'development') ? 'http://localhost:40
 
 function callApi(endpoint, method = 'get', body = {}) {
   const fullUrl = (endpoint.indexOf(API_HOST) === -1) ? API_HOST + endpoint : endpoint;
-  const options = {
+  let options = {
     method,
     headers: {
       Accept: 'application/vnd.api+json',
@@ -21,7 +21,7 @@ function callApi(endpoint, method = 'get', body = {}) {
       },
     };
 
-    options[body] = JSON.stringify(normalizedBody);
+    options = Object.assign(options, { body: JSON.stringify(normalizedBody) });
   }
 
   return fetch(fullUrl, options)
@@ -52,3 +52,5 @@ function callApi(endpoint, method = 'get', body = {}) {
 
 export const fetchAccounts = () => callApi('accounts');
 export const fetchAccount = id => callApi(`accounts/${id}`);
+
+export const signInUser = (email, password) => callApi('auth/token', 'post', { email, password });

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -59,3 +59,4 @@ export const fetchAccounts = () => callApi('accounts');
 export const fetchAccount = id => callApi(`accounts/${id}`);
 
 export const signInUser = (email, password) => callApi('auth/token', 'post', {}, { email, password });
+export const signOutUser = authToken => callApi('auth/token', 'delete', { Authorization: authToken });


### PR DESCRIPTION
This closes #1 

This huge PR adds authentication for OpenBudget UI. It calls `POST /auth/token` for signing in and `DELETE /auth/token` for signing out.

When a user signs in successfully, they get an access token from OpenBudget Core which then gets stored inside their `localStorage` for future API calls.

When a user signs out, the application will call `DELETE /auth/token` and tell the server to delete the user's token which means a new token will be generated upon the next sign in.

I know these commits don't have any test. This app has little to no tests to begin with, but I'll work on adding them eventually once I learn how to do them.