### PR TITLE
Properly pass auth tokens to requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add [Code of Conduct](CODE_OF_CONDUCT.md)
 - Add [Contributing Guidelines](CONTRIBUTING.md)
 
+### Changed
+
+- Pass auth tokens to all Accounts endpoints now.
+
+### Fixed
+
+- Fix the way we're passing auth tokens when signing out users.
+
 ## 0.1.0 - 2017-10-14
 
 ### Added

--- a/src/sagas/accounts.js
+++ b/src/sagas/accounts.js
@@ -10,7 +10,7 @@ import {
 
 function* fetchAccounts() {
   const { resolve, reject } = yield take(FETCH_ACCOUNTS_REQUEST);
-  const { response, error } = yield call(api.fetchAccounts);
+  const { response, error } = yield call(api.fetchAccounts, localStorage.getItem('authToken'));
 
   if (response && !error) {
     resolve();

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -59,4 +59,4 @@ export const fetchAccounts = () => callApi('accounts');
 export const fetchAccount = id => callApi(`accounts/${id}`);
 
 export const signInUser = (email, password) => callApi('auth/token', 'post', {}, { email, password });
-export const signOutUser = authToken => callApi('auth/token', 'delete', { Authorization: authToken });
+export const signOutUser = authToken => callApi('auth/token', 'delete', { Authorization: `Bearer ${authToken}` });

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -55,8 +55,8 @@ function callApi(endpoint, method = 'get', headers = {}, body = {}) {
     );
 }
 
-export const fetchAccounts = () => callApi('accounts');
-export const fetchAccount = id => callApi(`accounts/${id}`);
+export const fetchAccounts = authToken => callApi('accounts', 'get', { Authorization: `Bearer ${authToken}` });
+export const fetchAccount = (id, authToken) => callApi(`accounts/${id}`, 'get', { Authorization: `Bearer ${authToken}` });
 
 export const signInUser = (email, password) => callApi('auth/token', 'post', {}, { email, password });
 export const signOutUser = authToken => callApi('auth/token', 'delete', { Authorization: `Bearer ${authToken}` });


### PR DESCRIPTION
When signing out users, we weren't actually passing the Authorization header properly. It looked like this previously:

```
Authorization: <auth token here>
```

This PR fixes this issue by changing the request header to this:

```
Authorization: Bearer <auth token here>
```

This PR also changes the Accounts endpoint requests to pass an auth token alongside it.