### PR TITLE
Change url to app.openbudget.xyz

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 ## Overview
 
-* [OpenBudget](https://openbudget.xyz) is an open source envelope budgeting platform inspired by popular budgeting apps like [YNAB](https://youneedabudget.com) and [GoodBudget](https://goodbudget.com).
+* [OpenBudget](https://www.openbudget.xyz) is an open source envelope budgeting platform inspired by popular budgeting apps like [YNAB](https://youneedabudget.com) and [GoodBudget](https://goodbudget.com).
 * This is the user interface for [OpenBudget Core](https://github.com/obudget/core), which is also an open source project.
-* A public deployment of this code is maintained at [openbudget.xyz](https://openbudget.xyz)
+* A public deployment of this code is maintained at [app.openbudget.xyz](https://app.openbudget.xyz)
 
 ## Why Open Source?
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "license": "GPL-3.0",
+  "homepage": "https://app.openbudget.xyz",
   "dependencies": {
     "connected-react-router": "^4.2.3",
     "history": "^4.7.2",


### PR DESCRIPTION
I decided to change the URL of this app into app.openbudget.xyz. I felt like this is the best move because we can use the main domain for static website stuff like blogs, about pages and plain old SEO.