### PR TITLE
Add headers in API response object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Switch UI framework to [Semantic UI](https://react.semantic-ui.com). ([#24](https://github.com/obudget/ui/pull/24))
 - Pass auth tokens to all Accounts endpoints now. ([#26](https://github.com/obudget/ui/pull/26))
+- Add headers to API response objects. [#31](https://github.com/obudget/ui/pull/31)
 
 ### Fixed
 

--- a/src/actions/authentication.js
+++ b/src/actions/authentication.js
@@ -13,9 +13,9 @@ export const signInRequest = (values, resolve, reject) => ({
   reject,
 });
 
-export const signInSuccess = data => ({
+export const signInSuccess = authToken => ({
   type: SIGN_IN_SUCCESS,
-  authToken: data.access_token,
+  authToken,
 });
 
 export const signInFailure = error => ({

--- a/src/sagas/accounts.js
+++ b/src/sagas/accounts.js
@@ -15,8 +15,8 @@ function* fetchAccounts() {
   if (response && !error) {
     resolve();
     let normalizedAccounts = [];
-    if (Object.keys(response).length > 0) {
-      normalizedAccounts = Object.entries(response.account).map(account => ({
+    if (Object.keys(response.body).length > 0) {
+      normalizedAccounts = Object.entries(response.body.account).map(account => ({
         id: account[1].id,
         name: account[1].attributes.name,
         description: account[1].attributes.description,

--- a/src/sagas/authentication.js
+++ b/src/sagas/authentication.js
@@ -15,8 +15,9 @@ export function* signInUser() {
   const { response, error } = yield call(api.signInUser, values.email, values.password);
   if (response && !error) {
     resolve();
-    localStorage.setItem('authToken', response.access_token);
-    yield put(signInSuccess(response));
+    const authorizationHeader = response.headers.get('Authorization');
+    localStorage.setItem('authToken', authorizationHeader);
+    yield put(signInSuccess(authorizationHeader));
   } else {
     reject();
     yield put(signInFailure(error));

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -47,7 +47,7 @@ function callApi(endpoint, method = 'get', headers = {}, body = {}) {
       }
 
       window.hithere = returnObject;
-      return returnObject;
+      return { body: returnObject, headers: response.headers };
     })
     .then(
       response => ({ response }),
@@ -55,8 +55,8 @@ function callApi(endpoint, method = 'get', headers = {}, body = {}) {
     );
 }
 
-export const fetchAccounts = authToken => callApi('accounts', 'get', { Authorization: `Bearer ${authToken}` });
-export const fetchAccount = (id, authToken) => callApi(`accounts/${id}`, 'get', { Authorization: `Bearer ${authToken}` });
+export const fetchAccounts = authToken => callApi('accounts', 'get', { Authorization: authToken });
+export const fetchAccount = (id, authToken) => callApi(`accounts/${id}`, 'get', { Authorization: authToken });
 
 export const signInUser = (email, password) => callApi('auth/token', 'post', {}, { email, password });
-export const signOutUser = authToken => callApi('auth/token', 'delete', { Authorization: `Bearer ${authToken}` });
+export const signOutUser = authToken => callApi('auth/token', 'delete', { Authorization: authToken });


### PR DESCRIPTION
In API.js, whenever we interact with the API, we're actually only returning the body as the response afterwards.

I figured we need to have the header in that response as well because some saga methods may require it.