### PR TITLE
Force all saga functions to listen to actions more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fix the way we're passing auth tokens when signing out users. ([#26](https://github.com/obudget/ui/pull/26))
+- Force all saga functions to listen to actions more than once. [#42](https://github.com/obudget/ui/pull/42)
 
 ## 0.1.0 - 2017-10-14
 

--- a/src/sagas/accounts.js
+++ b/src/sagas/accounts.js
@@ -24,58 +24,64 @@ const normalizeAccounts = (collection) => {
 };
 
 export function* fetchAccounts() {
-  const { resolve, reject } = yield take(FETCH_ACCOUNTS_REQUEST);
-  const { response, error } = yield call(api.fetchAccounts, localStorage.getItem('authToken'));
+  while (true) {
+    const { resolve, reject } = yield take(FETCH_ACCOUNTS_REQUEST);
+    const { response, error } = yield call(api.fetchAccounts, localStorage.getItem('authToken'));
 
-  if (response && !error) {
-    resolve();
-    let normalizedAccounts = [];
-    if (Object.keys(response.body).length > 0) {
-      normalizedAccounts = normalizeAccounts(response.body.account);
+    if (response && !error) {
+      resolve();
+      let normalizedAccounts = [];
+      if (Object.keys(response.body).length > 0) {
+        normalizedAccounts = normalizeAccounts(response.body.account);
+      }
+      yield put(fetchAccountsSuccess(normalizedAccounts));
+    } else {
+      reject();
+      yield put(fetchAccountsFailure(error));
     }
-    yield put(fetchAccountsSuccess(normalizedAccounts));
-  } else {
-    reject();
-    yield put(fetchAccountsFailure(error));
   }
 }
 
 export function* fetchAccount() {
-  const { resolve, reject, id } = yield take(FETCH_ACCOUNT_REQUEST);
-  const { response, error } = yield call(api.fetchAccount, id, localStorage.getItem('authToken'));
+  while (true) {
+    const { resolve, reject, id } = yield take(FETCH_ACCOUNT_REQUEST);
+    const { response, error } = yield call(api.fetchAccount, id, localStorage.getItem('authToken'));
 
-  if (response && !error) {
-    resolve();
-    let normalizedAccounts = [];
-    if (Object.keys(response.body).length > 0) {
-      normalizedAccounts = normalizeAccounts(response.body.account);
+    if (response && !error) {
+      resolve();
+      let normalizedAccounts = [];
+      if (Object.keys(response.body).length > 0) {
+        normalizedAccounts = normalizeAccounts(response.body.account);
+      }
+      yield put(fetchAccountSuccess(normalizedAccounts[0]));
+    } else {
+      reject();
+      yield put(fetchAccountFailure(error));
     }
-    yield put(fetchAccountSuccess(normalizedAccounts[0]));
-  } else {
-    reject();
-    yield put(fetchAccountFailure(error));
   }
 }
 
 export function* createAccount() {
-  const { values, resolve, reject } = yield take(CREATE_ACCOUNT_REQUEST);
-  const { response, error } = yield call(
-    api.createAccount,
-    values.account_name,
-    values.account_description,
-    values.account_category,
-    localStorage.getItem('authToken'),
-  );
+  while (true) {
+    const { values, resolve, reject } = yield take(CREATE_ACCOUNT_REQUEST);
+    const { response, error } = yield call(
+      api.createAccount,
+      values.account_name,
+      values.account_description,
+      values.account_category,
+      localStorage.getItem('authToken'),
+    );
 
-  if (response && !error) {
-    resolve();
-    let normalizedAccounts = [];
-    if (Object.keys(response.body).length > 0) {
-      normalizedAccounts = normalizeAccounts(response.body.account);
+    if (response && !error) {
+      resolve();
+      let normalizedAccounts = [];
+      if (Object.keys(response.body).length > 0) {
+        normalizedAccounts = normalizeAccounts(response.body.account);
+      }
+      yield put(createAccountSuccess(normalizedAccounts[0]));
+    } else {
+      reject();
+      yield put(createAccountFailure(error));
     }
-    yield put(createAccountSuccess(normalizedAccounts[0]));
-  } else {
-    reject();
-    yield put(createAccountFailure(error));
   }
 }

--- a/src/sagas/authentication.js
+++ b/src/sagas/authentication.js
@@ -14,37 +14,43 @@ import {
 } from '../actions/authentication';
 
 export function* signInUser() {
-  const { values, resolve, reject } = yield take(SIGN_IN_REQUEST);
-  const { response, error } = yield call(api.signInUser, values.email, values.password);
-  if (response && !error) {
-    resolve();
-    const authorizationHeader = response.headers.get('Authorization');
-    localStorage.setItem('authToken', authorizationHeader);
-    yield put(signInSuccess(authorizationHeader));
-  } else {
-    reject();
-    yield put(signInFailure(error));
+  while (true) {
+    const { values, resolve, reject } = yield take(SIGN_IN_REQUEST);
+    const { response, error } = yield call(api.signInUser, values.email, values.password);
+    if (response && !error) {
+      resolve();
+      const authorizationHeader = response.headers.get('Authorization');
+      localStorage.setItem('authToken', authorizationHeader);
+      yield put(signInSuccess(authorizationHeader));
+    } else {
+      reject();
+      yield put(signInFailure(error));
+    }
   }
 }
 
 export function* signOutUser() {
-  const { resolve } = yield take(SIGN_OUT_REQUEST);
-  yield call(api.signOutUser, localStorage.getItem('authToken'));
+  while (true) {
+    const { resolve } = yield take(SIGN_OUT_REQUEST);
+    yield call(api.signOutUser, localStorage.getItem('authToken'));
 
-  resolve();
-  localStorage.removeItem('authToken');
-  yield put(signOutSuccess());
+    resolve();
+    localStorage.removeItem('authToken');
+    yield put(signOutSuccess());
+  }
 }
 
 export function* signUpUser() {
-  const { values, resolve, reject } = yield take(SIGN_UP_REQUEST);
-  const { response, error } = yield call(api.signUpUser, values.email, values.password);
-  if (response && !error) {
-    resolve();
-    localStorage.setItem('authToken', response.access_token);
-    yield put(signUpSuccess(response));
-  } else {
-    reject();
-    yield put(signUpFailure(error));
+  while (true) {
+    const { values, resolve, reject } = yield take(SIGN_UP_REQUEST);
+    const { response, error } = yield call(api.signUpUser, values.email, values.password);
+    if (response && !error) {
+      resolve();
+      localStorage.setItem('authToken', response.access_token);
+      yield put(signUpSuccess(response));
+    } else {
+      reject();
+      yield put(signUpFailure(error));
+    }
   }
 }

--- a/src/sagas/budgets.js
+++ b/src/sagas/budgets.js
@@ -17,19 +17,21 @@ const normalizeBudgets = (collection) => {
 };
 
 function* fetchBudgets() {
-  const { resolve, reject } = yield take(FETCH_BUDGETS_REQUEST);
-  const { response, error } = yield call(api.fetchBudgets, localStorage.getItem('authToken'));
+  while (true) {
+    const { resolve, reject } = yield take(FETCH_BUDGETS_REQUEST);
+    const { response, error } = yield call(api.fetchBudgets, localStorage.getItem('authToken'));
 
-  if (response && !error) {
-    resolve();
-    let normalizedBudgets = [];
-    if (Object.keys(response.body).length > 0) {
-      normalizedBudgets = normalizeBudgets(response.body.budget);
+    if (response && !error) {
+      resolve();
+      let normalizedBudgets = [];
+      if (Object.keys(response.body).length > 0) {
+        normalizedBudgets = normalizeBudgets(response.body.budget);
+      }
+      yield put(fetchBudgetsSuccess(normalizedBudgets));
+    } else {
+      reject();
+      yield put(fetchBudgetsFailure(error));
     }
-    yield put(fetchBudgetsSuccess(normalizedBudgets));
-  } else {
-    reject();
-    yield put(fetchBudgetsFailure(error));
   }
 }
 


### PR DESCRIPTION
This closes #41.

Sagas now do actions more than once. Previously, you can really only trigger a saga once and you'd have to refresh again if you want to trigger it further.. This PR fixes that issue.