### PR TITLE
Fix retrieval of auth header token after successful sign up

### DIFF
--- a/src/sagas/authentication.js
+++ b/src/sagas/authentication.js
@@ -52,7 +52,8 @@ export function* signUpUser() {
     const { response, error } = yield call(api.signUpUser, values.email, values.password);
     if (response && !error) {
       resolve();
-      localStorage.setItem('authToken', response.access_token);
+      const authorizationHeader = response.headers.get('Authorization');
+      localStorage.setItem('authToken', authorizationHeader);
       yield put(signUpSuccess(response));
       yield put(push('/'));
     } else {


### PR DESCRIPTION
This closes #45.

I seem to have forgotten to do this in #31. Signing up should store the authentication token properly this time.