### PR TITLE
Allow budget accounts to be deleted

### DIFF
--- a/src/actions/accounts.js
+++ b/src/actions/accounts.js
@@ -10,6 +10,9 @@ export const CREATE_ACCOUNT_FAILURE = 'CREATE_ACCOUNT_FAILURE';
 export const UPDATE_ACCOUNT_REQUEST = 'UPDATE_ACCOUNT_REQUEST';
 export const UPDATE_ACCOUNT_SUCCESS = 'UPDATE_ACCOUNT_SUCCESS';
 export const UPDATE_ACCOUNT_FAILURE = 'UPDATE_ACCOUNT_FAILURE';
+export const DELETE_ACCOUNT_REQUEST = 'DELETE_ACCOUNT_REQUEST';
+export const DELETE_ACCOUNT_SUCCESS = 'DELETE_ACCOUNT_SUCCESS';
+export const DELETE_ACCOUNT_FAILURE = 'DELETE_ACCOUNT_FAILURE';
 
 export const fetchAccountsRequest = (resolve, reject) => ({
   type: FETCH_ACCOUNTS_REQUEST,
@@ -75,5 +78,21 @@ export const updateAccountSuccess = account => ({
 
 export const updateAccountFailure = error => ({
   type: UPDATE_ACCOUNT_FAILURE,
+  message: error.message,
+});
+
+export const deleteAccountRequest = (id, resolve, reject) => ({
+  type: DELETE_ACCOUNT_REQUEST,
+  id,
+  resolve,
+  reject,
+});
+
+export const deleteAccountSuccess = () => ({
+  type: DELETE_ACCOUNT_SUCCESS,
+});
+
+export const deleteAccountFailure = error => ({
+  type: DELETE_ACCOUNT_FAILURE,
   message: error.message,
 });

--- a/src/components/Accounts/Pages/List/List.jsx
+++ b/src/components/Accounts/Pages/List/List.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Container, Table } from 'semantic-ui-react';
+import { Button, Container, Table } from 'semantic-ui-react';
 import { Link } from 'react-router-dom';
 
-import { fetchAccountsRequest } from '../../../../actions/accounts';
+import { fetchAccountsRequest, deleteAccountRequest } from '../../../../actions/accounts';
 
-export const List = ({ accounts }) => (
+export const List = ({ accounts, onAccountDeleteClick }) => (
   <Container>
     <Table celled>
       <Table.Header>
@@ -15,6 +15,8 @@ export const List = ({ accounts }) => (
           <Table.HeaderCell>Name</Table.HeaderCell>
           <Table.HeaderCell>Description</Table.HeaderCell>
           <Table.HeaderCell>Category</Table.HeaderCell>
+          <Table.HeaderCell />
+          <Table.HeaderCell />
         </Table.Row>
       </Table.Header>
       <Table.Body>
@@ -25,6 +27,12 @@ export const List = ({ accounts }) => (
               <Table.Cell><Link to={`/accounts/${account.id}`}>{account.name}</Link></Table.Cell>
               <Table.Cell>{account.description}</Table.Cell>
               <Table.Cell>{account.category}</Table.Cell>
+              <Table.Cell>
+                <Button as={Link} to={`/accounts/${account.id}/edit`}>Edit</Button>
+              </Table.Cell>
+              <Table.Cell>
+                <Button onClick={onAccountDeleteClick} color="red">Delete</Button>
+              </Table.Cell>
             </Table.Row>
           );
         })}
@@ -40,19 +48,19 @@ List.propTypes = {
     description: PropTypes.string,
     category: PropTypes.string.isRequired,
   }).isRequired).isRequired,
+  onAccountDeleteClick: PropTypes.func.isRequired,
 };
 
 class AccountsList extends React.Component {
-  componentDidMount() {
-    return new Promise((resolve, reject) => {
-      this.props.dispatch(fetchAccountsRequest(resolve, reject));
-    });
+  componentWillMount() {
+    this.props.fetchAccounts();
   }
 
   render() {
     return (
       <List
         accounts={this.props.accounts}
+        onAccountDeleteClick={this.props.onAccountDeleteClick}
       />
     );
   }
@@ -65,7 +73,8 @@ AccountsList.propTypes = {
     description: PropTypes.string,
     category: PropTypes.string.isRequired,
   }).isRequired).isRequired,
-  dispatch: PropTypes.func.isRequired,
+  fetchAccounts: PropTypes.func.isRequired,
+  onAccountDeleteClick: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (state) => {
@@ -74,4 +83,17 @@ const mapStateToProps = (state) => {
   };
 };
 
-export default connect(mapStateToProps, null)(AccountsList);
+const mapDispatchToProps = dispatch => ({
+  fetchAccounts: () => {
+    return new Promise((resolve, reject) => {
+      dispatch(fetchAccountsRequest(resolve, reject));
+    });
+  },
+  onAccountDeleteClick: (id) => {
+    return new Promise((resolve, reject) => {
+      dispatch(deleteAccountRequest(id, resolve, reject));
+    });
+  },
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(AccountsList);

--- a/src/components/Accounts/Pages/List/List.jsx
+++ b/src/components/Accounts/Pages/List/List.jsx
@@ -31,7 +31,9 @@ export const List = ({ accounts, onAccountDeleteClick }) => (
                 <Button as={Link} to={`/accounts/${account.id}/edit`}>Edit</Button>
               </Table.Cell>
               <Table.Cell>
-                <Button onClick={onAccountDeleteClick} color="red">Delete</Button>
+                <Button onClick={() => onAccountDeleteClick(account.id)} color="red">
+                  Delete
+                </Button>
               </Table.Cell>
             </Table.Row>
           );

--- a/src/reducers/accounts.js
+++ b/src/reducers/accounts.js
@@ -11,6 +11,9 @@ import {
   UPDATE_ACCOUNT_REQUEST,
   UPDATE_ACCOUNT_SUCCESS,
   UPDATE_ACCOUNT_FAILURE,
+  DELETE_ACCOUNT_REQUEST,
+  DELETE_ACCOUNT_SUCCESS,
+  DELETE_ACCOUNT_FAILURE,
 } from '../actions/accounts';
 
 const initialState = {
@@ -116,6 +119,28 @@ const accounts = (state = initialState, { type, ...payload }) => {
         message: null,
       };
     case UPDATE_ACCOUNT_FAILURE:
+      return {
+        ...state,
+        isFetching: false,
+        success: false,
+        message: payload.message,
+      };
+    case DELETE_ACCOUNT_REQUEST:
+      return {
+        ...state,
+        isFetching: true,
+        success: false,
+        message: null,
+      };
+    case DELETE_ACCOUNT_SUCCESS:
+      return {
+        ...state,
+        activeAccount: null,
+        isFetching: false,
+        success: true,
+        message: null,
+      };
+    case DELETE_ACCOUNT_FAILURE:
       return {
         ...state,
         isFetching: false,

--- a/src/sagas/accounts.js
+++ b/src/sagas/accounts.js
@@ -5,6 +5,7 @@ import { api } from '../services';
 
 import {
   FETCH_ACCOUNTS_REQUEST,
+  fetchAccountsRequest,
   fetchAccountsSuccess,
   fetchAccountsFailure,
   FETCH_ACCOUNT_REQUEST,
@@ -16,6 +17,9 @@ import {
   UPDATE_ACCOUNT_REQUEST,
   updateAccountSuccess,
   updateAccountFailure,
+  DELETE_ACCOUNT_REQUEST,
+  deleteAccountSuccess,
+  deleteAccountFailure,
 } from '../actions/accounts';
 
 const normalizeAccounts = (collection) => {
@@ -114,6 +118,23 @@ export function* updateAccount() {
     } else {
       reject();
       yield put(updateAccountFailure(error));
+    }
+  }
+}
+
+export function* deleteAccount() {
+  while (true) {
+    const { id, resolve, reject } = yield take(DELETE_ACCOUNT_REQUEST);
+    const { response, error } = yield call(api.deleteAccount, id, localStorage.getItem('authToken'));
+    window.hello = response;
+
+    if (response === undefined) {
+      resolve();
+      yield put(deleteAccountSuccess());
+      yield put(fetchAccountsRequest(resolve, reject));
+    } else {
+      reject();
+      yield put(deleteAccountFailure(error));
     }
   }
 }

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -1,6 +1,12 @@
 import { fork } from 'redux-saga/effects';
 
-import { fetchAccounts, fetchAccount, createAccount, updateAccount } from './accounts';
+import {
+  fetchAccounts,
+  fetchAccount,
+  createAccount,
+  updateAccount,
+  deleteAccount,
+} from './accounts';
 import { signInUser, signOutUser, signUpUser, requireAuthentication } from './authentication';
 import fetchBudgets from './budgets';
 
@@ -9,6 +15,7 @@ export default function* rootSaga() {
   yield fork(fetchAccount);
   yield fork(createAccount);
   yield fork(updateAccount);
+  yield fork(deleteAccount);
   yield fork(fetchBudgets);
   yield fork(signInUser);
   yield fork(signOutUser);

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -59,6 +59,7 @@ export const createAccount = (name, description, category, authToken) => callApi
 export const updateAccount = (id, name, description, category, authToken) => {
   return callApi(`accounts/${id}`, 'put', { Authorization: authToken }, { name, description, category });
 };
+export const deleteAccount = (id, authToken) => callApi(`accounts/${id}`, 'delete', { Authorization: authToken });
 
 export const fetchBudgets = authToken => callApi('budgets', 'get', { Authorization: authToken });
 


### PR DESCRIPTION
This closes #14.

This PR adds some buttons to the Account list page which includes the Delete button. The delete button interacts with the API to delete the selected budget accounts.