### PR TITLE
Store default budgets on user authentication

### DIFF
--- a/src/actions/authentication.js
+++ b/src/actions/authentication.js
@@ -52,9 +52,9 @@ export const signUpRequest = (values, resolve, reject) => ({
   reject,
 });
 
-export const signUpSuccess = data => ({
+export const signUpSuccess = authToken => ({
   type: SIGN_UP_SUCCESS,
-  authToken: data.access_token,
+  authToken,
 });
 
 export const signUpFailure = error => ({

--- a/src/reducers/authentication.js
+++ b/src/reducers/authentication.js
@@ -89,6 +89,7 @@ const authentication = (state = initialState, { type, ...payload }) => {
         isFetching: false,
         success: true,
         message: null,
+        authToken: payload.authToken,
       };
     case SIGN_UP_FAILURE:
       return {

--- a/src/sagas/authentication.js
+++ b/src/sagas/authentication.js
@@ -59,8 +59,11 @@ export function* signUpUser() {
     if (response && !error) {
       resolve();
       const authorizationHeader = response.headers.get('Authorization');
+      const defaultBudgetId = Object.entries(response.body.budget)[0][1].id;
       localStorage.setItem('authToken', authorizationHeader);
+      localStorage.setItem('defaultBudgetId', defaultBudgetId);
       yield put(signUpSuccess(authorizationHeader));
+      yield put(switchBudgetSuccess(defaultBudgetId));
       yield put(push('/'));
     } else {
       reject();

--- a/src/sagas/authentication.js
+++ b/src/sagas/authentication.js
@@ -46,6 +46,7 @@ export function* signOutUser() {
 
     resolve();
     localStorage.removeItem('authToken');
+    localStorage.removeItem('defaultBudgetId');
     yield put(signOutSuccess());
     yield put(push('/'));
   }

--- a/src/sagas/authentication.js
+++ b/src/sagas/authentication.js
@@ -59,7 +59,7 @@ export function* signUpUser() {
       resolve();
       const authorizationHeader = response.headers.get('Authorization');
       localStorage.setItem('authToken', authorizationHeader);
-      yield put(signUpSuccess(response));
+      yield put(signUpSuccess(authorizationHeader));
       yield put(push('/'));
     } else {
       reject();

--- a/src/sagas/authentication.js
+++ b/src/sagas/authentication.js
@@ -17,6 +17,8 @@ import {
   userAuthenticationCheckFailure,
 } from '../actions/authentication';
 
+import { switchBudgetSuccess } from '../actions/budgets';
+
 export function* signInUser() {
   while (true) {
     const { values, resolve, reject } = yield take(SIGN_IN_REQUEST);
@@ -24,8 +26,11 @@ export function* signInUser() {
     if (response && !error) {
       resolve();
       const authorizationHeader = response.headers.get('Authorization');
+      const defaultBudgetId = Object.entries(response.body.budget)[0][1].id;
       localStorage.setItem('authToken', authorizationHeader);
+      localStorage.setItem('defaultBudgetId', defaultBudgetId);
       yield put(signInSuccess(authorizationHeader));
+      yield put(switchBudgetSuccess(defaultBudgetId));
       yield put(push('/'));
     } else {
       reject();


### PR DESCRIPTION
This PR adds some improvements to the way we handle authentication:

1. It now stores the default budget id on sign in/up.
2. It fixes a bug where the auth token wasn't properly stored inside our reducers.